### PR TITLE
Run every 1 min for dev and 1 hour for prod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,7 @@ pom.xml.asc
 /.lein-*
 /.nrepl-port
 
+.eastwood
+
 .ruby-gemset
 .ruby-version

--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
     [clojure.java-time "0.3.2"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.36"]
+    [open-company/lib "0.16.37"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let
@@ -54,7 +54,7 @@
   ]
 
   :plugins [
-    [lein-ring "0.12.4"]
+    [lein-ring "0.12.5"]
     [lein-environ "1.1.0"] ; Get environment settings from different sources https://github.com/weavejester/environ
   ]
 
@@ -95,6 +95,7 @@
         :aws-sqs-notify-queue "CHANGE-ME"
         :liberator-trace "true"
         :log-level "debug"
+        :schedule-period "minutes" ; a tick every minute is better for development
       }
       :plugins [
         ;; Check for code smells https://github.com/dakrone/lein-bikeshed
@@ -148,6 +149,7 @@
                  '[oc.lib.db.common :as db-common]
                  '[oc.lib.schema :as lib-schema]
                  '[oc.lib.jwt :as jwt]
+                 '[oc.reminder.config :as config]
                  '[oc.reminder.resources.reminder :as reminder]
                  '[oc.reminder.resources.user :as u]
                  '[oc.reminder.representations.reminder :as reminder-rep])

--- a/src/oc/reminder/config.clj
+++ b/src/oc/reminder/config.clj
@@ -1,6 +1,8 @@
 (ns oc.reminder.config
   "Namespace for the configuration parameters."
-  (:require [environ.core :refer (env)]))
+  (:require [environ.core :refer (env)]
+            [java-time :as jt]
+            [tick.core :as tick]))
 
 (defn- bool
   "Handle the fact that we may have true/false strings, when we want booleans."
@@ -67,3 +69,9 @@
 ;; ----- JWT -----
 
 (defonce passphrase (env :open-company-auth-passphrase))
+
+;; ----- Schedule -----
+
+(defonce schedule-period (keyword (or (env :schedule-period ) "hours")))
+(defonce schedule-fn (if (= schedule-period :minutes) jt/minutes jt/hours))
+(defonce schedule-tick (if (= schedule-period :minutes) tick/minutes tick/hours))


### PR DESCRIPTION
When developing with reminders, more useful to have them being checked every minute than every hour. Rather than having to change the scheduler all the time, this PR does it with env config.

To test:
- Comment out line 98 in `project.clj`
- Start the REPL
- Run `(go)`
- [x] Look at the next run time, is it at the top of the next hour? Good!
- Stop the REPL
- Comment in line 98 in `project.clj`
- Start the REPL
- Run `(go)`
- [x] Look at the next run time, is it at the top of the next minute? Good!
- [x] Wait up to 1 min, does the run happen cleanly? Outstanding.
- Stop the REPL
- Start the server with `lein start!`
- [x] Look at the next run time, is it at the top of the next hour? Good!
- Merge
- Deploy
- Eat a Manhattan bagel